### PR TITLE
[Fix] some additional logic for re-using fasta

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           nextflow run ${GITHUB_WORKSPACE} "$TOWER" -name "$RUN_NAME-basic" -profile test,docker
       - uses: actions/upload-artifact@v1
+        if: always()
         name: Upload results
         with:
           name: results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,4 +33,4 @@ jobs:
         name: Upload results
         with:
           name: results
-          path: ${GITHUB_WORKSPACE}/results
+          path: results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v1
+        name: Checkout sources
       - name: Docker pull OpenMS image
         run: docker pull openms/executables
       - name: Extract branch name
@@ -27,3 +28,8 @@ jobs:
       - name:  BASIC Run the basic pipeline with the test
         run: |
           nextflow run ${GITHUB_WORKSPACE} "$TOWER" -name "$RUN_NAME-basic" -profile test,docker
+      - uses: actions/upload-artifact@v1
+        name: Upload results
+        with:
+          name: results
+          path: ${GITHUB_WORKSPACE}/results

--- a/conf/test.config
+++ b/conf/test.config
@@ -24,5 +24,6 @@ params {
   ]
   database = 'https://github.com/nf-core/test-datasets/raw/proteomicslfq/testdata/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta'
   expdesign = 'https://github.com/nf-core/test-datasets/raw/proteomicslfq/testdata/BSA_design.tsv'
-  skipPercolator = true
+  posterior_probabilities = "fit_distributions"
+  search_engine = "msgf"
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -26,4 +26,5 @@ params {
   expdesign = 'https://github.com/nf-core/test-datasets/raw/proteomicslfq/testdata/BSA_design.tsv'
   posterior_probabilities = "fit_distributions"
   search_engine = "msgf"
+  protein_level_fdr_cutoff = 1.0
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -24,4 +24,5 @@ params {
   ]
   database = 'https://github.com/nf-core/test-datasets/raw/proteomicslfq/testdata/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta'
   expdesign = 'https://github.com/nf-core/test-datasets/raw/proteomicslfq/testdata/BSA_design.tsv'
+  skipPercolator = true
 }

--- a/main.nf
+++ b/main.nf
@@ -593,6 +593,7 @@ process proteomicslfq {
                     -threads ${task.cpus} \\
                     -out_msstats out.csv \\
                     -out_cxml out.consensusXML \\
+                    -proteinFDR ${params.protein_level_fdr_cutoff} \\
                     -debug 667
 
      """

--- a/main.nf
+++ b/main.nf
@@ -576,6 +576,9 @@ process proteomicslfq {
      file "out.mzTab" into out_mzTab
      file "out.consensusXML" into out_consensusXML
      file "out.csv" into out_msstats
+     file "debug_mergedIDs.idXML" into debug_id
+     file "debug_mergedIDs_inference.idXML" into debug_id_inf
+     file "debug_mergedIDsGreedyResolved.idXML" into debug_id_resolve
 
     script:
      """

--- a/main.nf
+++ b/main.nf
@@ -578,7 +578,7 @@ process proteomicslfq {
      file "out.csv" into out_msstats
      file "debug_mergedIDs.idXML" into debug_id
      file "debug_mergedIDs_inference.idXML" into debug_id_inf
-     file "debug_mergedIDsGreedyResolved.idXML" into debug_id_resolve
+     //file "debug_mergedIDsGreedyResolved.idXML" into debug_id_resolve
 
     script:
      """

--- a/main.nf
+++ b/main.nf
@@ -419,8 +419,8 @@ process proteomicslfq {
      //id_files_str = id_files.sort().join(' ')
      //mzmls_str = mzmls.sort().join(' ')
      """
-     ProteomicsLFQ -in ${(mzmls as List).join(' ')} \\
-                    -ids ${(id_files as List).join(' ')} \\
+     ProteomicsLFQ -in ${(mzmls as List).sort().join(' ')} \\
+                    -ids ${(id_files as List).sort().join(' ')} \\
                     -design ${expdes} \\
                     -fasta ${fasta} \\
                     -targeted_only "true" \\

--- a/main.nf
+++ b/main.nf
@@ -23,26 +23,51 @@ def helpMessage() {
     Mandatory arguments:
       --spectra                     Path to input spectra as mzML or Thermo Raw
       --database                    Path to input protein database as fasta
-      -profile                      Configuration profile to use. Can use multiple (comma separated)
-                                    Available: conda, docker, singularity, awsbatch, test and more.
 
-    Mass Spectrometry Search:
+
+    Database Search:
+      --search_engine               Which search engine: "comet" or "msgf"
       --enzyme                      Enzymatic cleavage ('unspecific cleavage', 'Trypsin', see OpenMS enzymes)
       --fixed_mods                  Fixed modifications ('Carbamidomethyl (C)', see OpenMS modifications)
       --variable_mods               Variable modifications ('Oxidation (M)', see OpenMS modifications)
       --precursor_mass_tolerance    Mass tolerance of precursor mass (ppm)
       --allowed_missed_cleavages    Allowed missed cleavages 
-      --psm_level_fdr_cutoff        Identification PSM-level FDR 
-      --protein_level_fdr_cutoff    Identification protein-level FDR
+      --psm_level_fdr_cutoff        Identification PSM-level FDR cutoff
+      --posterior_probabilities     How to calculate posterior probabilities for PSMs:
+                                    "percolator" = Re-score based on PSM-feature-based SVM and transform distance
+                                        to hyperplane for posteriors 
+                                    "fit_distributions" = Fit positive and negative distributions to scores
+                                        (similar to PeptideProphet)
 
-    Options:
-      --expdesign                   Path to experimental design file
-      --adddecoys                   Add decoys to the given fasta
 
-    Other options:
+    Inference:
+      --protein_inference           Infer proteins through:
+                                    "aggregation"  = aggregates all peptide scores across a protein (by calculating the maximum)
+                                    "bayesian"     = computes a posterior probability for every protein based on a Bayesian network
+      --protein_level_fdr_cutoff    Identification protein-level FDR cutoff
+
+    Quantification:
+      --transfer_ids                Transfer IDs over aligned samples to increase # of quantifiable features (WARNING:
+                                    increased memory consumption)
+      --targeted_only               Only ID based quantification
+      --mass_recalibration          Recalibrates masses to correct for instrument biases
+      --protein_quantification      Quantify proteins based on:
+                                    "unique_peptides" = use peptides mapping to single proteins or a group of indistinguishable proteins (according to the set of experimentally identified peptides)
+                                    "strictly_unique_peptides" = use peptides mapping to a unique single protein only
+                                    "shared_peptides" = use shared peptides only for its best group (by inference score)
+
+    General Options:
+      --expdesign                   Path to experimental design file (if not given, it assumes unfractionated, unrelated samples)
+      --add_decoys                  Add decoys to the given fasta
+
+    Other nextflow options:
       --outdir                      The output directory where the results will be saved
-      --email                       Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits
-      -name                         Name for the pipeline run. If not specified, Nextflow will automatically generate a random mnemonic.
+      --email                       Set this parameter to your e-mail address to get a summary e-mail with details of the
+                                    run sent to you when the workflow exits
+      -name                         Name for the pipeline run. If not specified, Nextflow will automatically generate a random
+                                    mnemonic.
+      -profile                      Configuration profile to use. Can use multiple (comma separated)
+                                    Available: conda, docker, singularity, awsbatch, test and more.
 
     """.stripIndent()
 }
@@ -117,6 +142,18 @@ branched_input.mzML
 //This piece only runs on data that is a.) raw and b.) needs conversion
 //mzML files will be mixed after this step to provide output for downstream processing - allowing you to even specify mzMLs and RAW files in a mixed mode as input :-) 
 
+
+//GENERAL TODOS
+// - Check why we depend on full filepaths and if that is needed
+/* Proposition from nextflow gitter https://gitter.im/nextflow-io/nextflow?at=5e25fabea259cb0f0607a1a1
+*
+* unless the specific filenames are important (depends on the tool you're using), I usually use the pattern outlined here:
+* https://www.nextflow.io/docs/latest/process.html#multiple-input-files
+* e.g: file "?????.mzML" from mzmls_plfq.toSortedList() and ProteomicsLFQ -in *.mzML -ids *.id
+*/
+// - Check how to avoid copying of the database for example (currently we get one copy for each SE run). Is it the
+//   "each file()" pattern I used?
+
 /*
  * STEP 0.1 - Raw file conversion
  */
@@ -168,51 +205,30 @@ if (params.expdesign)
 
 
 //Fill the channels with empty Channels in case that we want to add decoys. Otherwise fill with output from database.
-(searchengine_in_db, pepidx_in_db, plfq_in_db) = ( params.adddecoys
+(searchengine_in_db, pepidx_in_db, plfq_in_db) = ( params.add_decoys
                     ? [ Channel.empty(), Channel.empty(), Channel.empty() ]
                     : [ Channel.fromPath(params.database),Channel.fromPath(params.database), Channel.fromPath(params.database)  ] )   
 
-//Add decoys if params.adddecoys is set appropriately
+//Add decoys if params.add_decoys is set appropriately
 process generate_decoy_database {
 
-input:
-    file(mydatabase) from db_for_decoy_creation
+    input:
+        file(mydatabase) from db_for_decoy_creation
 
-output:
-    file "${database.baseName}_decoy.fasta" into searchengine_in_db_decoy, pepidx_in_db_decoy, plfq_in_db_decoy
-    //TODO need to add these channel with .mix(searchengine_in_db_decoy) for example to all subsequent processes that need this...
+    output:
+        file "${database.baseName}_decoy.fasta" into searchengine_in_db_decoy, pepidx_in_db_decoy, plfq_in_db_decoy
+        //TODO need to add these channel with .mix(searchengine_in_db_decoy) for example to all subsequent processes that need this...
 
-when: params.adddecoys
+    when: params.add_decoys
 
-script:
-    """
-    DecoyDatabase  -in ${mydatabase} \\
-                -out ${mydatabase.baseName}_decoy.fasta \\
-                -decoy_string DECOY_ \\
-                -decoy_string_position prefix
-    """
+    script:
+        """
+        DecoyDatabase  -in ${mydatabase} \\
+                    -out ${mydatabase.baseName}_decoy.fasta \\
+                    -decoy_string DECOY_ \\
+                    -decoy_string_position prefix
+        """
 }
-
-
-// Test
-//process generate_simple_exp_design_file {
-//    publishDir "${params.outdir}", mode: 'copy'
-//    input:
-//     val mymzmls from mzmls.collect()
-
-//    output:
-//     file "expdesign.csv" into expdesign
-
-//    when:
-//     !params.expdesign 
- 
-//    script:
-//     strng = mymzmls.join(',')
-//     """
-//       echo ${strng} > expdesign.csv
-//     """
-//}
-
 
 // Doesnt work. Py script needs all the inputs to be together in a folder
 // Wont work with nextflow. It needs to accept a list of paths for the inputs!!
@@ -234,43 +250,53 @@ script:
 //}
 
 /// Search engine
-// TODO parameterize
-if (params.se == "msgf")
+// TODO parameterize more
+if (params.search_engine == "msgf")
 {
-   process search_engine_msgf {
-    echo true
-    input:
-     file database from searchengine_in_db.mix(searchengine_in_db_decoy)
-     each file(mzml_file) from mzmls
+   search_engine_score = "SpecEValue"
 
-    output:
-     file "${mzml_file.baseName}.idXML" into id_files
- 
-    script:
-     """
-     MSGFPlusAdapter  -in ${mzml_file} \\
-                   -out ${mzml_file.baseName}.idXML \\
-                   -threads ${task.cpus} \\
-                   -database ${database}
-     """
+    process search_engine_msgf {
+        echo true
+        input:
+         tuple file(database), file(mzml_file) from searchengine_in_db.mix(searchengine_in_db_decoy).combine(mzmls)
+         
+         // This was another way of handling the combination
+         //file database from searchengine_in_db.mix(searchengine_in_db_decoy)
+         //each file(mzml_file) from mzmls
+
+
+        output:
+         file "${mzml_file.baseName}.idXML" into id_files
+     
+        script:
+         """
+         MSGFPlusAdapter  -in ${mzml_file} \\
+                       -out ${mzml_file.baseName}.idXML \\
+                       -threads ${task.cpus} \\
+                       -database ${database}
+         """
      }
-} else {
-    process search_engine_comet {
-    echo true
-    input:
-     file database from searchengine_in_db.mix(searchengine_in_db_decoy)
-     each file(mzml_file) from mzmls
 
-    output:
-     file "${mzml_file.baseName}.idXML" into id_files
- 
-    script:
-     """
-     CometAdapter  -in ${mzml_file} \\
-                   -out ${mzml_file.baseName}.idXML \\
-                   -threads ${task.cpus} \\
-                   -database ${database}
-     """
+} else {
+
+    search_engine_score = "expect"
+
+    process search_engine_comet {
+        echo true
+        input:
+         file database from searchengine_in_db.mix(searchengine_in_db_decoy)
+         each file(mzml_file) from mzmls
+
+        output:
+         file "${mzml_file.baseName}.idXML" into id_files
+     
+        script:
+         """
+         CometAdapter  -in ${mzml_file} \\
+                       -out ${mzml_file.baseName}.idXML \\
+                       -threads ${task.cpus} \\
+                       -database ${database}
+         """
      }
 }
 
@@ -283,7 +309,7 @@ process index_peptides {
      file database from pepidx_in_db.mix(pepidx_in_db_decoy)
      
     output:
-     file "${id_file.baseName}_idx.idXML" into id_files_idx, id_files_idx_2
+     file "${id_file.baseName}_idx.idXML" into id_files_idx_ForPerc, id_files_idx_ForIDPEP
 
     script:
      """
@@ -295,16 +321,21 @@ process index_peptides {
 
 }
 
+
+// ---------------------------------------------------------------------
+// Branch a) Q-values and PEP from Percolator
+
+
 process extract_perc_features {
  
     input:
-     file id_file from id_files_idx
+     file id_file from id_files_idx_ForPerc
 
     output:
      file "${id_file.baseName}_feat.idXML" into id_files_idx_feat
 
     when:
-     !params.skipPercolator
+     params.posterior_probabilities == "percolator"
 
     script:
      """
@@ -325,7 +356,7 @@ process percolator {
      file "${id_file.baseName}_perc.idXML" into id_files_idx_feat_perc
 
     when:
-     !params.skipPercolator
+     params.posterior_probabilities == "percolator"
 
     script:
      """
@@ -337,14 +368,68 @@ process percolator {
 
 }
 
-//TODO probably not needed when using Percolator. You can use the qval from there
+process idfilter {
+ 
+    publishDir "${params.outdir}/ids", mode: 'copy'
+
+    input:
+     file id_file from id_files_idx_feat_perc
+
+    output:
+     file "${id_file.baseName}_filter.idXML" into id_files_idx_feat_perc_filter
+
+    when:
+     params.posterior_probabilities == "percolator"
+
+    script:
+     """
+     IDFilter -in ${id_file} \\
+                        -out ${id_file.baseName}_filter.idXML \\
+                        -threads ${task.cpus} \\
+                        -score:pep ${params.psm_level_fdr_cutoff}
+     """
+
+}
+
+process idscoreswitcher {
+ 
+    input:
+     file id_file from id_files_idx_feat_perc_filter
+
+    output:
+     file "${id_file.baseName}_switched.idXML" into id_files_idx_feat_perc_fdr_filter_switched
+
+    when:
+     params.posterior_probabilities == "percolator"
+
+    script:
+     """
+     IDScoreSwitcher    -in ${id_file} \\
+                        -out ${id_file.baseName}_switched.idXML \\
+                        -threads ${task.cpus} \\
+                        -old_score q-value \\
+                        -new_score MS:1001493 \\
+                        -new_score_orientation lower_better \\
+                        -new_score_type "Posterior Error Probability"
+     """
+
+}
+
+
+
+// ---------------------------------------------------------------------
+// Branch b) Q-values and PEP from OpenMS
+
 process fdr {
  
     input:
-     file id_file from id_files_idx_feat_perc.mix(id_files_idx_2)
+     file id_file from id_files_idx_ForIDPEP
 
     output:
-     file "${id_file.baseName}_fdr.idXML" into id_files_idx_feat_perc_fdr
+     file "${id_file.baseName}_fdr.idXML" into id_files_idx_ForIDPEP_fdr
+
+    when:
+     params.posterior_probabilities != "percolator"
 
     script:
      """
@@ -356,47 +441,123 @@ process fdr {
 
 }
 
-
-// TODO parameterize
-process idfilter {
+process idscoreswitcher1 {
  
     input:
-     file id_file from id_files_idx_feat_perc_fdr
+     file id_file from id_files_idx_ForIDPEP_fdr
 
     output:
-     file "${id_file.baseName}_filter.idXML" into id_files_idx_feat_perc_fdr_filter, id_files_idx_feat_perc_fdr_filter_2 
+     file "${id_file.baseName}_switched.idXML" into id_files_idx_ForIDPEP_fdr_switch
 
+    when:
+     params.posterior_probabilities != "percolator"
+
+    script:
+     """
+     IDScoreSwitcher    -in ${id_file} \\
+                        -out ${id_file.baseName}_switched.idXML \\
+                        -threads ${task.cpus} \\
+                        -old_score q-value \\
+                        -new_score ${search_engine_score}_score \\
+                        -new_score_orientation lower_better \\
+                        -new_score_type ${search_engine_score}
+     """
+
+}
+
+//TODO probably not needed when using Percolator. You can use the qval from there
+process idpep {
+ 
+    input:
+     file id_file from id_files_idx_ForIDPEP_fdr_switch
+
+    output:
+     file "${id_file.baseName}_idpep.idXML" into id_files_idx_ForIDPEP_fdr_switch_idpep
+
+    when:
+     params.posterior_probabilities != "percolator"
+
+    script:
+     """
+     IDPosteriorErrorProbability    -in ${id_file} \\
+                                    -out ${id_file.baseName}_idpep.idXML \\
+                                    -threads ${task.cpus}
+     """
+
+}
+
+process idscoreswitcher2 {
+ 
+    input:
+     file id_file from id_files_idx_ForIDPEP_fdr_switch_idpep
+
+    output:
+     file "${id_file.baseName}_switched.idXML" into id_files_idx_ForIDPEP_fdr_switch_idpep_switch
+
+    when:
+     params.posterior_probabilities != "percolator"
+
+    script:
+     """
+     IDScoreSwitcher    -in ${id_file} \\
+                        -out ${id_file.baseName}_switched.idXML \\
+                        -threads ${task.cpus} \\
+                        -old_score "Posterior Error Probability" \\
+                        -new_score q-value \\
+                        -new_score_orientation lower_better
+     """
+
+}
+
+process idfilter2 {
+ 
+    publishDir "${params.outdir}/ids", mode: 'copy'
+
+    input:
+     file id_file from id_files_idx_ForIDPEP_fdr_switch_idpep_switch
+
+    output:
+     file "${id_file.baseName}_filter.idXML" into id_files_idx_ForIDPEP_fdr_switch_idpep_switch_filter
+
+    when:
+     params.posterior_probabilities != "percolator"
+      
     script:
      """
      IDFilter -in ${id_file} \\
                         -out ${id_file.baseName}_filter.idXML \\
                         -threads ${task.cpus} \\
-                        -score:pep 0.05
+                        -score:pep ${params.psm_level_fdr_cutoff}
      """
 
 }
 
-//TODO check if needed
-process idscoreswitcher {
+process idscoreswitcher3 {
  
     input:
-     file id_file from id_files_idx_feat_perc_fdr_filter
+     file id_file from id_files_idx_ForIDPEP_fdr_switch_idpep_switch_filter
 
     output:
-     file "${id_file.baseName}_switched.idXML" into id_files_idx_feat_perc_fdr_filter_switched
+     file "${id_file.baseName}_switched.idXML" into id_files_idx_ForIDPEP_fdr_switch_idpep_switch_filter_switch
 
     when:
-     !params.skipPercolator
+     params.posterior_probabilities != "percolator"
 
     script:
      """
-     IDScoreSwitcher -in ${id_file} \\
+     IDScoreSwitcher    -in ${id_file} \\
                         -out ${id_file.baseName}_switched.idXML \\
                         -threads ${task.cpus} \\
-                        -old_score q-value -new_score MS:1001493 -new_score_orientation lower_better -new_score_type "Posterior Error Probability"
+                        -old_score q-value \\
+                        -new_score "Posterior Error Probability" \\
+                        -new_score_orientation lower_better
      """
 
 }
+
+
+// ---------------------------------------------------------------------
+// Main Branch
 
 process proteomicslfq {
  
@@ -404,7 +565,10 @@ process proteomicslfq {
     
     input:
      file mzmls from mzmls_plfq.toSortedList({ a, b -> b.baseName <=> a.baseName }).view()
-     file id_files from id_files_idx_feat_perc_fdr_filter_switched.mix(id_files_idx_feat_perc_fdr_filter_2).toSortedList({ a, b -> b.baseName <=> a.baseName }).view()
+     file id_files from id_files_idx_feat_perc_fdr_filter_switched
+         .mix(id_files_idx_ForIDPEP_fdr_switch_idpep_switch_filter_switch)
+         .toSortedList({ a, b -> b.baseName <=> a.baseName })
+         .view()
      file expdes from expdesign
      file fasta from plfq_in_db.mix(plfq_in_db_decoy)
 
@@ -421,6 +585,7 @@ process proteomicslfq {
                     -fasta ${fasta} \\
                     -targeted_only "true" \\
                     -mass_recalibration "false" \\
+                    -transfer_ids "false" \\
                     -out out.mzTab \\
                     -threads ${task.cpus} \\
                     -out_msstats out.csv \\
@@ -430,6 +595,15 @@ process proteomicslfq {
      """
 
 }
+
+
+
+
+
+//--------------------------------------------------------------- //
+//---------------------- Nextflow specifics --------------------- //
+//--------------------------------------------------------------- //
+
 
 // Header log info
 log.info nfcoreHeader()
@@ -500,7 +674,8 @@ process get_software_versions {
 /*
  * STEP 3 - Output Description HTML
  */
-/*process output_documentation {
+/* TODO Deactivated for now
+process output_documentation {
     publishDir "${params.outdir}/pipeline_info", mode: 'copy'
 
     input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,9 +12,22 @@ params {
   // TODO nf-core: Specify your pipeline's command line flags
   spectra = "data/*.mzML"
   database = "data/*.fasta"
-  //expdesign = "data/*.tsv"
-  adddecoys = false
-  se = "comet"
+  expdesign = "data/*.tsv"
+  posterior_probabilities = "percolator"
+  transfer_ids = false
+  targeted_only = false
+  mass_recalibration = true
+  add_decoys = false
+  search_engine = "comet"
+  protein_inference = "aggregation"
+  precursor_mass_tolerance = 5
+  enzyme = 'Trypsin'
+  fixed_mods = 'Carbamidomethyl (C)'
+  variable_mods = 'Oxidation (M)'
+  allowed_missed_cleavages = 1
+  psm_level_fdr_cutoff = 0.05
+  protein_level_fdr_cutoff = 0.05
+
   outdir = './results'
 
   // Boilerplate options
@@ -37,14 +50,7 @@ params {
   config_profile_contact = false
   config_profile_url = false
 
-  //workflow defaults
-  precursor_mass_tolerance = 5
-  enzyme = 'unspecific cleavage'
-  fixed_mods = ''
-  variable_mods = 'Oxidation (M)'
-  allowed_missed_cleavages = 0
-  psm_level_fdr_cutoff = 0.05
-  protein_level_fdr_cutoff = 0.05
+
 }
 
 // Container slug. Stable releases should specify release tag!

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,6 +13,8 @@ params {
   spectra = "data/*.mzML"
   database = "data/*.fasta"
   //expdesign = "data/*.tsv"
+  adddecoys = false
+  se = "comet"
   outdir = './results'
 
   // Boilerplate options


### PR DESCRIPTION
Currently skips percolator to be able to test until ProteomicLFQ.
Also adds indexing step, if the original mzMLs were not indexed.