### PR TITLE
Use file basename as ID, instead of a hash of the row.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
   - defaults
 dependencies:
   - openms::openms=2.7.0pre
-  - openms::openms-thirdparty=2.7.0pre # 25.11.2020
+  - openms::openms-thirdparty=2.7.0pre # 27.11.2020
   - bioconda::bioconductor-msstats=3.20.1 # will include R
   - bioconda::sdrf-pipelines=0.0.9 # for SDRF conversion
   - conda-forge::r-ptxqc=1.0.5 # for QC reports

--- a/main.nf
+++ b/main.nf
@@ -226,7 +226,7 @@ if (!sdrf_file)
 {
   ch_spectra = Channel.fromPath(spectra_files, checkIfExists: true)
   ch_spectra
-  .multiMap{ it -> id = it.toString().md5()
+  .multiMap{ it -> id = file(it).name.take(file(it).name.lastIndexOf('.'))
                     comet_settings: msgf_settings: tuple(id,
                                     params.fixed_mods,
                                     params.variable_mods,
@@ -276,7 +276,7 @@ else
   //TODO use header and reference by col name instead of index
   ch_sdrf_config_file
   .splitCsv(skip: 1, sep: '\t')
-  .multiMap{ row -> id = row.toString().md5()
+  .multiMap{ row -> id = file(row[0].toString()).name.take(file(row[0].toString()).name.lastIndexOf('.'))
                     comet_settings: msgf_settings: tuple(id,
                                     row[2],
                                     row[3],


### PR DESCRIPTION
Easier to read, and I think sufficient for uniqueness.
Might also lead to less cache misses when resuming.

## PR checklist

- [X] This comment contains a description of changes (with reason)

