### PR TITLE
[FEATURE] Add "newish" max_MC param to MSGF

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -563,7 +563,7 @@ process search_engine_msgf {
                      -max_precursor_charge ${params.max_precursor_charge} \\
                      -min_peptide_length ${params.min_peptide_length} \\
                      -max_peptide_length ${params.max_peptide_length} \\
-		     -max_missed_cleavages ${params.allowed_missed_cleavages} \\
+                     -max_missed_cleavages ${params.allowed_missed_cleavages} \\
                      -enzyme "${enzyme}" \\
                      -tryptic ${msgf_num_enzyme_termini} \\
                      -precursor_mass_tolerance ${prec_tol} \\

--- a/main.nf
+++ b/main.nf
@@ -563,6 +563,7 @@ process search_engine_msgf {
                      -max_precursor_charge ${params.max_precursor_charge} \\
                      -min_peptide_length ${params.min_peptide_length} \\
                      -max_peptide_length ${params.max_peptide_length} \\
+		     -max_missed_cleavages ${params.allowed_missed_cleavages} \\
                      -enzyme "${enzyme}" \\
                      -tryptic ${msgf_num_enzyme_termini} \\
                      -precursor_mass_tolerance ${prec_tol} \\


### PR DESCRIPTION
It was not present in the Thirdparty MSGF of OpenMS 2.5.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests! (automatically part of the main tests)
- [x] Documentation in `docs` is updated (the diverging behaviour was never mentioned)
- [x] If necessary, also make a PR on the [nf-core/proteomicslfq branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/proteomicslfq)
