### PR TITLE
Require experimental design with filenames to only have string type as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,21 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.1.0 - Best Batman [TBD]
+## v2.0.0 - Best Batman [TBD]
 
-Patch update, mainly for documentation fixes.
+Major update with slightly different interface (experimental designs are the main source of input now). Following the newest nfcore schemata.
+New OpenMS and thirdparty versions. New pipeline features (especially for downstream processing and QC) and a few fixed bugs.
 
 ### `Added`
 
 * Speed improvements and multithreading of proteomicslfq process
 * Option for tree-guided map alignment
 * Link to description of the OpenMS experimental design format in the parameter usage docs
+* **IMPORTANT**: `input` has to be an experimental design file now that includes all file paths.
 * Output for post-processing with Triqler including an option to quantify decoys
 * Refinement of alignment and linking tolerances across runs
 * Many more options for the MSstats step incl. user-specified contrasts.
+* PMultiQC as additional QC tool/step 
 
 ### `Known issues`
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -16,16 +16,8 @@ params {
   max_time = 48.h
 
   // Input data
-  input = [
-    'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA1_F1.mzML',
-    'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA1_F2.mzML',
-    'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA2_F1.mzML',
-    'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA2_F2.mzML',
-    'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA3_F1.mzML',
-    'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA3_F2.mzML'
-  ]
+  input = https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA_design.tsv
   database = 'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta'
-  expdesign = 'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA_design.tsv'
   posterior_probabilities = "fit_distributions"
   search_engines = "msgf"
   decoy_affix = "rev"

--- a/conf/test.config
+++ b/conf/test.config
@@ -16,7 +16,7 @@ params {
   max_time = 48.h
 
   // Input data
-  input = https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA_design.tsv
+  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA_design.tsv'
   database = 'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta'
   posterior_probabilities = "fit_distributions"
   search_engines = "msgf"
@@ -26,7 +26,4 @@ params {
   // data is VERY small, we need to report everything that we find to have enough for all steps
   protein_level_fdr_cutoff = 1.0
   msstats_remove_one_feat_prot = false
-
-  // Ignore `--input` as otherwise the parameter validation will throw an error
-  schema_ignore_params = 'input'
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -14,24 +14,13 @@ params {
   config_profile_description = 'Full test dataset to check pipeline function'
 
   // Input data
-  input = [
-    'ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2015/12/PXD001819/UPS1_2500amol_R1.raw',
-    'ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2015/12/PXD001819/UPS1_2500amol_R2.raw',
-    'ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2015/12/PXD001819/UPS1_2500amol_R3.raw',
-    'ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2015/12/PXD001819/UPS1_50000amol_R1.raw',
-    'ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2015/12/PXD001819/UPS1_50000amol_R2.raw',
-    'ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2015/12/PXD001819/UPS1_50000amol_R3.raw'
-  ]
-
-  database = 'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata-aws/uniprot_yeast_reviewed_isoforms_ups1_crap.fasta_td.fasta'
-  expdesign = 'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata-aws/experimental_design_short.tsv'
+  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata-aws/experimental_design_short.tsv'
+  database = 'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata-aws/yeast_UPS.fasta'
   posterior_probabilities = "percolator"
   search_engines = "comet,msgf"
   psm_pep_fdr_cutoff = 0.05
+  add_decoys = true
   decoy_affix = "rev"
   protein_inference = "bayesian"
   targeted_only = "false"
-  
-  // Ignore `--input` as otherwise the parameter validation will throw an error
-  schema_ignore_params = 'input'
 }

--- a/conf/test_speccount.config
+++ b/conf/test_speccount.config
@@ -17,7 +17,7 @@ params {
   max_time = 1.h
 
   // Input data
-  input = https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA_design.tsv
+  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA_design.tsv'
   database = 'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta'
   posterior_probabilities = "fit_distributions"
   quantification_method="spectral_counting"

--- a/conf/test_speccount.config
+++ b/conf/test_speccount.config
@@ -17,16 +17,8 @@ params {
   max_time = 1.h
 
   // Input data
-  input = [
-    'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA1_F1.mzML',
-    'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA1_F2.mzML',
-    'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA2_F1.mzML',
-    'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA2_F2.mzML',
-    'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA3_F1.mzML',
-    'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA3_F2.mzML'
-  ]
+  input = https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA_design.tsv
   database = 'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta'
-  expdesign = 'https://raw.githubusercontent.com/nf-core/test-datasets/proteomicslfq/testdata/BSA_design.tsv'
   posterior_probabilities = "fit_distributions"
   quantification_method="spectral_counting"
   search_engines = "msgf"

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
   - defaults
 dependencies:
   - openms::openms=2.7.0pre
-  - openms::openms-thirdparty=2.7.0pre # 08.02.2021
+  - openms::openms-thirdparty=2.7.0pre # 29.09.2021
   - bioconda::bioconductor-msstats=3.22.1 # will include R
   - bioconda::sdrf-pipelines=0.0.14 # for SDRF conversion
   - bioconda::pmultiqc=0.0.5 # for proteomics plugin of multiqc

--- a/main.nf
+++ b/main.nf
@@ -82,6 +82,7 @@ if (isCollectionOrArray(params.input))
 }
 
 sdrf_file = null
+expdesign_file = null
 
 if (tocheck.toLowerCase().endsWith("sdrf") || tocheck.toLowerCase().endsWith("sdrf.tsv")) {
   sdrf_file = params.input

--- a/main.nf
+++ b/main.nf
@@ -85,10 +85,10 @@ sdrf_file = null
 
 if (tocheck.toLowerCase().endsWith("sdrf") || tocheck.toLowerCase().endsWith("sdrf.tsv")) {
   sdrf_file = params.input
-} else if (tocheck.toLowerCase().endsWith("tsv") {
+} else if (tocheck.toLowerCase().endsWith("tsv")) {
   expdesign_file = params.input
 } else {
-  log.error "EITHER an OpenMS-style experimental design OR an SDRF needs to be provided as input."; exit 1
+  log.error "EITHER an OpenMS-style experimental design (.tsv) OR an SDRF (.sdrf/.sdrf.tsv) needs to be provided as input."; exit 1
 }
 
 params.database = params.database ?: { log.error "No protein database provided. Make sure you have used the '--database' option."; exit 1 }()

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,12 +9,11 @@
 params {
 
   // Workflow flags
-  input = '' // the sdrf and spectra parameters are inferred from this one
+  input = '' // the sdrf and spectra parameters or the experimental design are inferred from this one
   input_paths = null
   root_folder = ''
   local_input_type = ''
   database = ''
-  expdesign = ''
 
   // Tools flags
   posterior_probabilities = 'percolator'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -17,8 +17,8 @@
                 "input": {
                     "type": "string",
                     "fa_icon": "fas fa-vials",
-                    "description": "URI/path to an [SDRF](https://github.com/bigbio/proteomics-metadata-standard/tree/master/annotated-projects) file **OR** globbing pattern for URIs/paths of mzML or Thermo RAW files",
-                    "help_text": "The input to the pipeline can be specified in two **mutually exclusive** ways:\n  - using a path or URI to a PRIDE Sample to Data Relation Format file (SDRF), e.g. as part of a submitted and\nannotated PRIDE experiment (see [here](https://github.com/bigbio/proteomics-metadata-standard/tree/master/annotated-projects) for examples). Input files will be downloaded and cached from the URIs specified in the SDRF file.\nAn OpenMS-style experimental design will be generated based on the factor columns of the SDRF. The settings for the\nfollowing parameters will currently be overwritten by the ones specified in the SDRF:\n\n    * `fixed_mods`,\n    * `variable_mods`,\n    * `precursor_mass_tolerance`,\n    * `precursor_mass_tolerance_unit`,\n    * `fragment_mass_tolerance`,\n    * `fragment_mass_tolerance_unit`,\n    * `fragment_method`,\n    * `enzyme`\n  - by specifying globbing patterns to the input spectrum files in Thermo RAW or mzML format (e.g. `/data/experiment{1,2,3}_rep*.mzML`). An experimental design should be provided with the `expdesign` parameter."},
+                    "description": "URI/path to an [SDRF](https://github.com/bigbio/proteomics-metadata-standard/tree/master/annotated-projects) file (with ending .sdrf or .sdrf.tsv) **OR** a tab-separated experimental design file (.tsv) in OpenMS' own [format](http://www.openms.de/doxygen/release/latest/html/classOpenMS_1_1ExperimentalDesign.html#details). All input files need to be specified with full paths in the corresponding columns. Those can be any URIs or local paths with schemata supported by nextflow (e.g. http/ftp/s3)",
+                    "help_text": "The input to the pipeline can be specified in two **mutually exclusive** ways:\n  - using a path or URI to a PRIDE Sample to Data Relation Format file (SDRF), e.g. as part of a submitted and\nannotated PRIDE experiment (see [here](https://github.com/bigbio/proteomics-metadata-standard/tree/master/annotated-projects) for examples). \nAn OpenMS-style experimental design will be generated based on the factor columns of the SDRF. The settings for the\nfollowing parameters will currently be overwritten by the ones specified in the SDRF:\n\n    * `fixed_mods`,\n    * `variable_mods`,\n    * `precursor_mass_tolerance`,\n    * `precursor_mass_tolerance_unit`,\n    * `fragment_mass_tolerance`,\n    * `fragment_mass_tolerance_unit`,\n    * `fragment_method`,\n    * `enzyme`\n  - by specifying a tab-separated experimental design file in OpenMS' own [format](http://www.openms.de/doxygen/release/latest/html/classOpenMS_1_1ExperimentalDesign.html#details). In this case, setting additional parameters is recommended. All input file paths/URIs will be used to download and cache inputs if necessary (i.e. remote files were used)."},
                 "outdir": {
                     "type": "string",
                     "description": "The output directory where the results will be saved.",
@@ -206,35 +206,22 @@
                 }
             }
         },
-        "main_parameters__sdrf_": {
-            "title": "Main parameters (SDRF)",
+        "staging": {
+            "title": "Staging of files",
             "type": "object",
-            "description": "In case your input was an SDRF files, the following optional parameters can be set.",
+            "description": "Allows to overwrite the origins and types of input files as specified in the input design/SDRF.",
             "properties": {
                 "root_folder": {
                     "type": "string",
-                    "description": "Root folder in which the spectrum files specified in the SDRF are searched",
+                    "description": "Root folder in which the spectrum files specified in the design/SDRF are searched",
                     "fa_icon": "fas fa-folder",
-                    "help_text": "This optional parameter can be used to specify a root folder in which the spectrum files specified in the SDRF are searched.\nIt is usually used if you have a local version of the experiment already. Note that this option does not support recursive\nsearching yet."
+                    "help_text": "This optional parameter can be used to specify a root folder in which the spectrum files specified in the design/SDRF are searched.\nIt is usually used if you have a local version of the experiment already. Note that this option does not support recursive\nsearching yet."
                 },
                 "local_input_type": {
                     "type": "string",
                     "description": "Overwrite the file type/extension of the filename as specified in the SDRF",
                     "fa_icon": "fas fa-file-invoice",
-                    "help_text": "If the above [`--root_folder`](#params_root_folder) was given to load local input files, this overwrites the file type/extension of\nthe filename as specified in the SDRF. Usually used in case you have an mzML-converted version of the files already. Needs to be\none of 'mzML' or 'raw' (the letter cases should match your files exactly)."
-                }
-            },
-            "fa_icon": "far fa-chart-bar"
-        },
-        "main_parameters__spectra_files_": {
-            "title": "Main parameters (spectra files)",
-            "type": "object",
-            "description": "In case your input was a globbing pattern to spectrum files in Thermo RAW or mzML format you can specify a manual OpenMS-style experimental design file here.",
-            "properties": {
-                "expdesign": {
-                    "type": "string",
-                    "description": "A tab-separated experimental design file in OpenMS' own [format](http://www.openms.de/doxygen/release/latest/html/classOpenMS_1_1ExperimentalDesign.html#details). All input files need to be present as a row with exactly the same names. If no design is given, unrelated, unfractionated runs are assumed.",
-                    "fa_icon": "fas fa-file-csv"
+                    "help_text": "If the above [`--root_folder`](#params_root_folder) was given to load local input files, this overwrites the file type/extension of\nthe filename as specified in the design/SDRF. Usually used in case you have an mzML-converted version of the files already. Needs to be\none of 'mzML' or 'raw' (the letter cases should match your files exactly)."
                 }
             },
             "fa_icon": "far fa-chart-bar"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -865,10 +865,7 @@
             "$ref": "#/definitions/institutional_config_options"
         },
         {
-            "$ref": "#/definitions/main_parameters__sdrf_"
-        },
-        {
-            "$ref": "#/definitions/main_parameters__spectra_files_"
+            "$ref": "#/definitions/staging"
         },
         {
             "$ref": "#/definitions/protein_database"


### PR DESCRIPTION
As requested on Slack. To be compatible with nf-tower.
This will lead to fewer errors but quite a bit more work for users.

Edit: More explanation:
One problem is that with the nf-core param schema, parameters need to have a specific type. String or List, where List isn't even supported yet. Therefore, the input parameter should not change the meaning in different "modes" of the workflow.
This is fixed now by always requiring an experimental design, from which also file locations are read. This can be an SDRF with parameters or a plain OpenMS experimental design. A root_folder and different filetype can be chosen in the "Staging" parameters to account for people using an experimental design after moving/downloading remote files or converting them. (this was possible before for SDRFs already).

I think this makes the interface a bit cleaner and allows full compatibility with all nf-core/nf-tower functionality.
However it is a bit more work for users. They can use the "create_simple_design.py" script for example and then edit in Excel or something.